### PR TITLE
Update build system to Babel

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,3 @@
+{
+  "extends": "appium"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 node_modules
-lib/es5
-test/es5
 *.log
+build

--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,2 @@
-node_modules/
 *.log
+test

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@ Apache License
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright {yyyy} {name of copyright owner}
+   Copyright 2014 Jonathan Lipps
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -199,4 +199,3 @@ Apache License
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-

--- a/README.md
+++ b/README.md
@@ -3,10 +3,13 @@ ES6-Mapify
 
 Convert JS Objects to ES6 Maps and vice versa.
 
-ES6 `Map` objects are really nice for iteration, but they're not so nice for directly referencing properties, the way JS Objects are. This is a nice way to convert back and forth. First, simply use `npm` to include `mapify` in your project's dependencies:
+ES6 `Map` objects are really nice for iteration, but they're not so nice for
+directly referencing properties, the way JS Objects are. This is a nice way to
+convert back and forth. First, simply use `npm` to include `es6-mapify` in your
+project's dependencies:
 
 ```
-npm install es6-mapify
+npm install -S es6-mapify
 ```
 
 Now you can import it and use it like so:

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,24 +1,11 @@
 "use strict";
 
-var gulp = require('gulp')
-  , merge = require('merge-stream')
-  , traceur = require('gulp-traceur');
+const gulp = require('gulp');
+const boilerplate = require('appium-gulp-plugins').boilerplate.use(gulp);
 
-gulp.task('default', function () {
-  var traceurOpts = {
-    asyncFunctions: true,
-    blockBinding: true,
-    modules: 'commonjs',
-    annotations: true,
-    arrayComprehension: true
-  };
-  var lib = gulp.src('lib/es6/**/*.js')
-                .pipe(traceur(traceurOpts))
-                .pipe(gulp.dest('lib/es5'));
-  var test = gulp.src('test/es6/**/*.js')
-                 .pipe(traceur(traceurOpts))
-                 .pipe(gulp.dest('test/es5'));
-  return merge(lib, test);
+boilerplate({
+  build: "ES6-Mapify",
+  test: {
+    files: ['${testDir}/**/*-specs.js']
+  },
 });
-
-

--- a/lib/main.js
+++ b/lib/main.js
@@ -14,7 +14,7 @@ function mapify (obj) {
     if (obj.hasOwnProperty(k)) {
       m.set(k, mapify(obj[k]));
     }
-  };
+  }
   return m;
 }
 
@@ -33,9 +33,8 @@ function demapify (map) {
     obj[k] = demapify(v);
   }
   return obj;
-};
+}
 
 let objify = demapify;
 
 export { mapify, demapify, objify };
-

--- a/package.json
+++ b/package.json
@@ -9,12 +9,7 @@
   ],
   "version": "1.0.0",
   "author": "jlipps@gmail.com",
-  "licenses": [
-    {
-      "type": "apache-2.0",
-      "url": "https://raw.github.com/jlipps/mapify/master/LICENSE"
-    }
-  ],
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/jlipps/mapify.git"
@@ -25,23 +20,29 @@
   "engines": [
     "node"
   ],
-  "main": "./lib/es5/main.js",
-  "bin": {
-  },
+  "main": "./build/lib/main.js",
+  "bin": {},
   "directories": {
     "lib": "./lib/es6"
   },
   "dependencies": {
-    "traceur": "~0.0.74"
+    "babel-runtime": "=5.8.24"
   },
   "scripts": {
-    "test": "$(npm bin)/gulp && $(npm bin)/mocha test/es5/specs.js"
+    "test": "gulp once",
+    "lint": "gulp eslint",
+    "buid": "gulp transpile",
+    "prepublish": "gulp prepublish"
   },
   "devDependencies": {
-    "gulp-traceur": "^0.13.0",
-    "gulp": "^3.8.9",
-    "merge-stream": "^0.1.6",
-    "mocha": "^2.0.1",
-    "should": "^4.1.0"
+    "appium-gulp-plugins": "^2.2.0",
+    "babel-eslint": "^7.1.1",
+    "chai": "^4.1.2",
+    "eslint": "^3.18.0",
+    "eslint-config-appium": "^2.0.1",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-mocha": "^4.7.0",
+    "eslint-plugin-promise": "^3.3.1",
+    "gulp": "^3.8.9"
   }
 }

--- a/test/mapify-specs.js
+++ b/test/mapify-specs.js
@@ -1,8 +1,8 @@
-/* global describe:true, it:true */
+import { mapify, demapify } from '../lib/main';
+import chai from 'chai';
 
-import 'traceur/bin/traceur-runtime';
-import should from 'should';
-import { mapify, demapify } from '../../lib/es5/main';
+
+chai.should();
 
 describe("mapify", () => {
   it("should return a non-object as is", () => {
@@ -10,7 +10,7 @@ describe("mapify", () => {
     mapify('hi').should.equal('hi');
     (typeof mapify(undefined)).should.eql('undefined');
     mapify([1, 2, 3]).should.eql([1, 2, 3]);
-    should.ok(mapify(null) === null);
+    (mapify(null) === null).should.be.true;
   });
 
   it("should convert an empty object", () => {
@@ -39,7 +39,7 @@ describe("mapify", () => {
     a[0].should.equal(1);
     a[2].should.equal(2);
     let m = a[1];
-    should.ok(a[1] instanceof Map);
+    (a[1] instanceof Map).should.be.true;
     m.get('a').should.equal('b');
   });
 


### PR DESCRIPTION
In keeping with the times, this updates the build to use babel. At the same time, add eslint.

This will remove traceur from the Appium toolchain altogether.